### PR TITLE
Fix admin login session handling

### DIFF
--- a/server/index.ts
+++ b/server/index.ts
@@ -1,10 +1,19 @@
 import express, { type Request, Response, NextFunction } from "express";
+import session from "express-session";
 import { registerRoutes } from "./routes";
 import { setupVite, serveStatic, log } from "./vite";
 
 const app = express();
 app.use(express.json());
 app.use(express.urlencoded({ extended: false }));
+app.use(
+  session({
+    secret: process.env.SESSION_SECRET || "keyboard cat",
+    resave: false,
+    saveUninitialized: false,
+    cookie: { maxAge: 24 * 60 * 60 * 1000 },
+  }),
+);
 
 app.use((req, res, next) => {
   const start = Date.now();

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -167,9 +167,8 @@ export async function registerRoutes(app: Express): Promise<Server> {
         return res.status(401).json({ message: "Invalid credentials" });
       }
       
-      // Simple session management
-      req.session = req.session || {};
-      (req.session as any).adminId = admin.id;
+      // Save admin id into the session
+      req.session.adminId = admin.id;
       
       res.json({ message: "Login successful", admin: { id: admin.id, email: admin.email } });
     } catch (error) {
@@ -178,13 +177,12 @@ export async function registerRoutes(app: Express): Promise<Server> {
   });
 
   app.post("/api/admin/logout", (req, res) => {
-    req.session = req.session || {};
-    delete (req.session as any).adminId;
+    delete req.session.adminId;
     res.json({ message: "Logout successful" });
   });
 
   app.get("/api/admin/me", (req, res) => {
-    const adminId = req.session && (req.session as any).adminId;
+    const adminId = req.session.adminId;
     if (!adminId) {
       return res.status(401).json({ message: "Not authenticated" });
     }

--- a/server/types.d.ts
+++ b/server/types.d.ts
@@ -1,0 +1,7 @@
+import 'express-session';
+
+declare module 'express-session' {
+  interface SessionData {
+    adminId?: number;
+  }
+}


### PR DESCRIPTION
## Summary
- enable express-session middleware
- keep admin auth in session and expose typing helper

## Testing
- `npm run check` *(fails: TypeScript errors in existing files)*

------
https://chatgpt.com/codex/tasks/task_b_687a0c838fc88321845b18c9340dc88f