### PR TITLE
Fix admin session persistence, add categories route

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -9,6 +9,7 @@ import Cart from "@/pages/cart";
 import Orders from "@/pages/orders";
 import AdminLogin from "@/pages/admin/login";
 import AdminDashboard from "@/pages/admin/dashboard";
+import CategoryPage from "@/pages/category";
 import NotFound from "@/pages/not-found";
 
 function Router() {
@@ -18,6 +19,7 @@ function Router() {
       <Route path="/product/:id" component={ProductDetail} />
       <Route path="/cart" component={Cart} />
       <Route path="/orders" component={Orders} />
+      <Route path="/category" component={CategoryPage} />
       <Route path="/admin/login" component={AdminLogin} />
       <Route path="/admin/dashboard" component={AdminDashboard} />
       <Route component={NotFound} />

--- a/client/src/components/layout/header.tsx
+++ b/client/src/components/layout/header.tsx
@@ -1,5 +1,6 @@
 import { useState } from "react";
 import { Link } from "wouter";
+import { useQuery } from "@tanstack/react-query";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuTrigger } from "@/components/ui/dropdown-menu";
@@ -13,6 +14,10 @@ interface HeaderProps {
 export default function Header({ onSearch }: HeaderProps) {
   const [searchQuery, setSearchQuery] = useState("");
   const { cartItems } = useCart();
+  const { data: auth } = useQuery<{ authenticated: boolean }>({
+    queryKey: ["/api/admin/me"],
+    retry: false,
+  });
 
   const handleSearchSubmit = (e: React.FormEvent) => {
     e.preventDefault();
@@ -117,12 +122,14 @@ export default function Header({ onSearch }: HeaderProps) {
                 )}
               </Button>
             </Link>
-            <Link href="/admin/login">
-              <Button variant="ghost" className="text-gray-700 hover:text-primary">
-                <User className="h-4 w-4 mr-2" />
-                Admin
-              </Button>
-            </Link>
+            {!auth?.authenticated && (
+              <Link href="/admin/login">
+                <Button variant="ghost" className="text-gray-700 hover:text-primary">
+                  <User className="h-4 w-4 mr-2" />
+                  Admin
+                </Button>
+              </Link>
+            )}
             <Button className="gradient-bg hover:opacity-90 text-white">
               Đăng nhập
             </Button>

--- a/client/src/pages/category.tsx
+++ b/client/src/pages/category.tsx
@@ -1,0 +1,36 @@
+import { useState, useEffect } from "react";
+import { useLocation } from "wouter";
+import Header from "@/components/layout/header";
+import Footer from "@/components/layout/footer";
+import CategoryFilter from "@/components/product/category-filter";
+import ProductGrid from "@/components/product/product-grid";
+
+export default function CategoryPage() {
+  const [location] = useLocation();
+  const [selectedCategory, setSelectedCategory] = useState<string>("all");
+  const [searchQuery, setSearchQuery] = useState<string>("");
+
+  useEffect(() => {
+    const params = new URLSearchParams(location.split('?')[1] || '');
+    const searchParam = params.get('search');
+    const categoryParam = params.get('category');
+    if (searchParam) {
+      setSearchQuery(searchParam);
+    }
+    if (categoryParam) {
+      setSelectedCategory(categoryParam);
+    }
+  }, [location]);
+
+  return (
+    <div className="min-h-screen bg-gray-50">
+      <Header onSearch={setSearchQuery} />
+      <CategoryFilter
+        selectedCategory={selectedCategory}
+        onCategoryChange={setSelectedCategory}
+      />
+      <ProductGrid category={selectedCategory} searchQuery={searchQuery} />
+      <Footer />
+    </div>
+  );
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -44,6 +44,7 @@
         "clsx": "^2.1.1",
         "cmdk": "^1.1.1",
         "connect-pg-simple": "^10.0.0",
+        "cors": "^2.8.5",
         "date-fns": "^3.6.0",
         "drizzle-orm": "^0.39.1",
         "drizzle-zod": "^0.7.0",
@@ -79,6 +80,7 @@
         "@tailwindcss/typography": "^0.5.15",
         "@tailwindcss/vite": "^4.1.3",
         "@types/connect-pg-simple": "^7.0.3",
+        "@types/cors": "^2.8.17",
         "@types/express": "4.17.21",
         "@types/express-session": "^1.18.0",
         "@types/node": "20.16.11",
@@ -3353,6 +3355,16 @@
         "@types/pg": "*"
       }
     },
+    "node_modules/@types/cors": {
+      "version": "2.8.19",
+      "resolved": "https://registry.npmjs.org/@types/cors/-/cors-2.8.19.tgz",
+      "integrity": "sha512-mFNylyeyqN93lfe/9CSxOGREz8cpzAhH+E93xJ4xWQf62V8sQ/24reV2nyzUWM6H6Xji+GGHpkbLe7pVoUEskg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/d3-array": {
       "version": "3.2.1",
       "resolved": "https://registry.npmjs.org/@types/d3-array/-/d3-array-3.2.1.tgz",
@@ -4265,6 +4277,19 @@
       "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
       "integrity": "sha512-QADzlaHc8icV8I7vbaJXJwod9HWYp8uCqf1xa4OfNu1T7JVxQIrUgOWtHdNDtPiywmFbiS12VjotIXLrKM3orQ==",
       "license": "MIT"
+    },
+    "node_modules/cors": {
+      "version": "2.8.5",
+      "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.5.tgz",
+      "integrity": "sha512-KIHbLJqu73RGr/hnbrO9uBeixNGuvSQjul/jdFvS/KFSIH1hWVd1ng7zOHx+YrEfInLG7q4n6GHQ9cDtxv/P6g==",
+      "license": "MIT",
+      "dependencies": {
+        "object-assign": "^4",
+        "vary": "^1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
     },
     "node_modules/cross-env": {
       "version": "7.0.3",

--- a/package.json
+++ b/package.json
@@ -75,7 +75,8 @@
     "wouter": "^3.3.5",
     "ws": "^8.18.0",
     "zod": "^3.24.2",
-    "zod-validation-error": "^3.4.0"
+    "zod-validation-error": "^3.4.0",
+    "cors": "^2.8.5"
   },
   "devDependencies": {
     "@replit/vite-plugin-cartographer": "^0.2.7",
@@ -101,7 +102,8 @@
     "tailwindcss": "^3.4.17",
     "tsx": "^4.19.1",
     "typescript": "5.6.3",
-    "vite": "^5.4.19"
+    "vite": "^5.4.19",
+    "@types/cors": "^2.8.17"
   },
   "optionalDependencies": {
     "bufferutil": "^4.0.8"

--- a/server/index.ts
+++ b/server/index.ts
@@ -1,5 +1,6 @@
 import express, { type Request, Response, NextFunction } from "express";
 import session from "express-session";
+import cors from "cors";
 import { registerRoutes } from "./routes";
 import { setupVite, serveStatic, log } from "./vite";
 
@@ -7,11 +8,20 @@ const app = express();
 app.use(express.json());
 app.use(express.urlencoded({ extended: false }));
 app.use(
+  cors({
+    origin: true,
+    credentials: true,
+  }),
+);
+app.use(
   session({
     secret: process.env.SESSION_SECRET || "keyboard cat",
     resave: false,
     saveUninitialized: false,
-    cookie: { maxAge: 24 * 60 * 60 * 1000 },
+    cookie: {
+      maxAge: 24 * 60 * 60 * 1000,
+      sameSite: "lax",
+    },
   }),
 );
 


### PR DESCRIPTION
## Summary
- use CORS so cookies are kept for login session
- hide admin button when already authenticated
- add a `/category` page to show product categories
- wire the new route in router
- install `cors` and `@types/cors`

## Testing
- `npm run check` *(fails: TS errors)*

------
https://chatgpt.com/codex/tasks/task_b_687a0f961fe883219ff2f802b1522594