### PR TITLE
Implement new public login and category routing

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -8,6 +8,7 @@ import ProductDetail from "@/pages/product-detail";
 import Cart from "@/pages/cart";
 import Orders from "@/pages/orders";
 import AdminLogin from "@/pages/admin/login";
+import Login from "@/pages/login";
 import AdminDashboard from "@/pages/admin/dashboard";
 import CategoryPage from "@/pages/category";
 import NotFound from "@/pages/not-found";
@@ -20,6 +21,7 @@ function Router() {
       <Route path="/cart" component={Cart} />
       <Route path="/orders" component={Orders} />
       <Route path="/category" component={CategoryPage} />
+      <Route path="/login" component={Login} />
       <Route path="/admin/login" component={AdminLogin} />
       <Route path="/admin/dashboard" component={AdminDashboard} />
       <Route component={NotFound} />

--- a/client/src/components/layout/header.tsx
+++ b/client/src/components/layout/header.tsx
@@ -1,11 +1,9 @@
 import { useState } from "react";
 import { Link } from "wouter";
-import { useQuery } from "@tanstack/react-query";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
-import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuTrigger } from "@/components/ui/dropdown-menu";
 import { useCart } from "@/hooks/use-cart";
-import { ShoppingBasket, Search, ShoppingCart, Menu, User, ChevronDown, Package, Apple, Beef, Milk, Egg, Wheat } from "lucide-react";
+import { ShoppingBasket, Search, ShoppingCart, Menu } from "lucide-react";
 
 interface HeaderProps {
   onSearch: (query: string) => void;
@@ -14,10 +12,6 @@ interface HeaderProps {
 export default function Header({ onSearch }: HeaderProps) {
   const [searchQuery, setSearchQuery] = useState("");
   const { cartItems } = useCart();
-  const { data: auth } = useQuery<{ authenticated: boolean }>({
-    queryKey: ["/api/admin/me"],
-    retry: false,
-  });
 
   const handleSearchSubmit = (e: React.FormEvent) => {
     e.preventDefault();
@@ -45,52 +39,11 @@ export default function Header({ onSearch }: HeaderProps) {
                 Trang chủ
               </Button>
             </Link>
-            <DropdownMenu>
-              <DropdownMenuTrigger asChild>
-                <Button variant="ghost" className="text-gray-700 hover:text-primary">
-                  Danh mục
-                  <ChevronDown className="h-4 w-4 ml-1" />
-                </Button>
-              </DropdownMenuTrigger>
-              <DropdownMenuContent align="start" className="w-48">
-                <DropdownMenuItem asChild>
-                  <Link href="/?category=all" className="flex items-center gap-2">
-                    <Package className="h-4 w-4" />
-                    Tất cả
-                  </Link>
-                </DropdownMenuItem>
-                <DropdownMenuItem asChild>
-                  <Link href="/?category=vegetables" className="flex items-center gap-2">
-                    <Apple className="h-4 w-4" />
-                    Rau củ
-                  </Link>
-                </DropdownMenuItem>
-                <DropdownMenuItem asChild>
-                  <Link href="/?category=meat" className="flex items-center gap-2">
-                    <Beef className="h-4 w-4" />
-                    Thịt cá
-                  </Link>
-                </DropdownMenuItem>
-                <DropdownMenuItem asChild>
-                  <Link href="/?category=dairy" className="flex items-center gap-2">
-                    <Milk className="h-4 w-4" />
-                    Sữa
-                  </Link>
-                </DropdownMenuItem>
-                <DropdownMenuItem asChild>
-                  <Link href="/?category=eggs" className="flex items-center gap-2">
-                    <Egg className="h-4 w-4" />
-                    Trứng
-                  </Link>
-                </DropdownMenuItem>
-                <DropdownMenuItem asChild>
-                  <Link href="/?category=dry" className="flex items-center gap-2">
-                    <Wheat className="h-4 w-4" />
-                    Đồ khô
-                  </Link>
-                </DropdownMenuItem>
-              </DropdownMenuContent>
-            </DropdownMenu>
+            <Link href="/category">
+              <Button variant="ghost" className="text-gray-700 hover:text-primary">
+                Danh mục
+              </Button>
+            </Link>
             <Link href="/orders">
               <Button variant="ghost" className="text-gray-700 hover:text-primary">
                 Đơn hàng
@@ -122,17 +75,11 @@ export default function Header({ onSearch }: HeaderProps) {
                 )}
               </Button>
             </Link>
-            {!auth?.authenticated && (
-              <Link href="/admin/login">
-                <Button variant="ghost" className="text-gray-700 hover:text-primary">
-                  <User className="h-4 w-4 mr-2" />
-                  Admin
-                </Button>
-              </Link>
-            )}
-            <Button className="gradient-bg hover:opacity-90 text-white">
-              Đăng nhập
-            </Button>
+            <Link href="/login">
+              <Button className="gradient-bg hover:opacity-90 text-white">
+                Đăng nhập
+              </Button>
+            </Link>
 
             {/* Mobile Menu Button */}
             <Button variant="ghost" className="md:hidden">

--- a/client/src/pages/category.tsx
+++ b/client/src/pages/category.tsx
@@ -6,28 +6,41 @@ import CategoryFilter from "@/components/product/category-filter";
 import ProductGrid from "@/components/product/product-grid";
 
 export default function CategoryPage() {
-  const [location] = useLocation();
+  const [location, setLocation] = useLocation();
   const [selectedCategory, setSelectedCategory] = useState<string>("all");
   const [searchQuery, setSearchQuery] = useState<string>("");
 
   useEffect(() => {
     const params = new URLSearchParams(location.split('?')[1] || '');
     const searchParam = params.get('search');
-    const categoryParam = params.get('category');
+    const typeParam = params.get('type');
     if (searchParam) {
       setSearchQuery(searchParam);
     }
-    if (categoryParam) {
-      setSelectedCategory(categoryParam);
+    if (typeParam) {
+      setSelectedCategory(typeParam);
+    } else {
+      setSelectedCategory('all');
     }
   }, [location]);
+
+  const handleCategoryChange = (category: string) => {
+    const params = new URLSearchParams(location.split('?')[1] || '');
+    if (category === 'all') {
+      params.delete('type');
+    } else {
+      params.set('type', category);
+    }
+    const queryString = params.toString();
+    setLocation(`/category${queryString ? `?${queryString}` : ''}`);
+  };
 
   return (
     <div className="min-h-screen bg-gray-50">
       <Header onSearch={setSearchQuery} />
       <CategoryFilter
         selectedCategory={selectedCategory}
-        onCategoryChange={setSelectedCategory}
+        onCategoryChange={handleCategoryChange}
       />
       <ProductGrid category={selectedCategory} searchQuery={searchQuery} />
       <Footer />

--- a/client/src/pages/login.tsx
+++ b/client/src/pages/login.tsx
@@ -1,0 +1,98 @@
+import { useState } from "react";
+import { useLocation } from "wouter";
+import { useMutation } from "@tanstack/react-query";
+import { apiRequest } from "@/lib/queryClient";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { useToast } from "@/hooks/use-toast";
+import { ShieldCheck, ArrowLeft } from "lucide-react";
+import { Link } from "wouter";
+
+export default function Login() {
+  const [email, setEmail] = useState("");
+  const [password, setPassword] = useState("");
+  const [, setLocation] = useLocation();
+  const { toast } = useToast();
+
+  const loginMutation = useMutation({
+    mutationFn: async (credentials: { email: string; password: string }) => {
+      const response = await apiRequest("POST", "/api/admin/login", credentials);
+      return response.json();
+    },
+    onSuccess: () => {
+      toast({
+        title: "Đăng nhập thành công",
+        description: "Chào mừng bạn đến với trang quản trị!",
+      });
+      setLocation("/admin/dashboard");
+    },
+    onError: (error: any) => {
+      toast({
+        title: "Đăng nhập thất bại",
+        description: error.message || "Thông tin đăng nhập không chính xác",
+        variant: "destructive",
+      });
+    },
+  });
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    loginMutation.mutate({ email, password });
+  };
+
+  return (
+    <div className="min-h-screen bg-gray-50 flex items-center justify-center p-4">
+      <Card className="w-full max-w-md animate-scale-up">
+        <CardHeader className="text-center">
+          <div className="flex justify-center mb-4">
+            <ShieldCheck className="h-12 w-12 text-primary" />
+          </div>
+          <CardTitle className="text-2xl font-bold text-gray-800">Đăng nhập</CardTitle>
+          <CardDescription>Đăng nhập để sử dụng hệ thống FoodMart</CardDescription>
+        </CardHeader>
+        <CardContent>
+          <form onSubmit={handleSubmit} className="space-y-4">
+            <div className="space-y-2">
+              <Label htmlFor="email">Email</Label>
+              <Input
+                id="email"
+                type="email"
+                placeholder="admin@foodmart.com"
+                value={email}
+                onChange={(e) => setEmail(e.target.value)}
+                required
+              />
+            </div>
+            <div className="space-y-2">
+              <Label htmlFor="password">Mật khẩu</Label>
+              <Input
+                id="password"
+                type="password"
+                placeholder="••••••••"
+                value={password}
+                onChange={(e) => setPassword(e.target.value)}
+                required
+              />
+            </div>
+            <Button
+              type="submit"
+              className="w-full gradient-bg hover:opacity-90"
+              disabled={loginMutation.isPending}
+            >
+              {loginMutation.isPending ? "Đang đăng nhập..." : "Đăng nhập"}
+            </Button>
+          </form>
+          <div className="mt-4 text-center">
+            <Link href="/">
+              <Button variant="ghost" className="text-sm">
+                <ArrowLeft className="h-4 w-4 mr-2" />Về trang chủ
+              </Button>
+            </Link>
+          </div>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add a separate `/login` page reusing the admin login UI
- update header navigation to link to `/category` and `/login`
- remove admin login link from the UI
- add query param handling for `/category` using `type`
- register new login route

## Testing
- `npm run check` *(fails: TS errors in existing files)*

------
https://chatgpt.com/codex/tasks/task_b_687a1263abf483218e40b9453f049691